### PR TITLE
Bundle and enable docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,39 @@ These two requests will include a merger of the `hx-drag` + `hx-drop` + `hx-vals
 
 ## Install
 
+### CDN
+
 ```html
 <script src="https://unpkg.com/hx-drag@2.0.0"></script>
+```
+
+### Bundle
+
+To bundle in an npm-style build system with ES modules, you will have to add `htmx` to the `document` like so:
+
+```
+npm i hx-drag
+```
+
+```javascript
+// index.js
+import "./htmx";
+import "hx-drag";
+```
+
+```javascript
+// htmx.js
+import htmx from "htmx.org";
+window.htmx = htmx; // to support hx-drag
+export default htmx;
+```
+
+## Enable
+
+```html
+<body hx-ext="drag">
+    ...
+</body>
 ```
 
 ## Styling


### PR DESCRIPTION
Added detail on how to bundle the extension when using npm.  It took me a little time to figure out.  This might be something worth promoting to an issue and fixing, since the current behavior of expecting `document.htmx`  is assuming one particular style of installation.  I'm not sure what the correct alternative is yet, though.

This change also explicitly tells users the registered extension name to use, otherwise they have to guess or look at the source code.

Feel free to suggest any changes, and thank you for the fully-featured HTMX extension!